### PR TITLE
Feature: cinder-rxt: Add configurable safety margin for LVM volume al…

### DIFF
--- a/cinder_rxt/rackspace.py
+++ b/cinder_rxt/rackspace.py
@@ -12,15 +12,54 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import math
 import string
 import textwrap
 
+from oslo_config import cfg
 from oslo_log import log as logging
+from oslo_utils import units
 
+from cinder import context as cinder_context
+from cinder import db as cinder_db
 from cinder.volume.drivers import lvm
 from cinder.volume.targets import tgt
 
 LOG = logging.getLogger(__name__)
+
+
+# Extra configuration options for the RXTLVM driver.
+# These are in addition to the base LVM driver's options.
+rxt_volume_opts = [
+    cfg.FloatOpt(
+        "safe_size_margin_gb",
+        default=0.25,
+        min=0.0,
+        help="""
+Additional backend space (in GiB) to allocate when creating LVM-backed
+volumes from images, snapshots or clones. This margin is **not**
+reflected in Cinder-reported volume size or quota accounting; it only
+affects the underlying LVM LV size.
+
+The actual margin used is aligned to the VG extent size. Set to 0.0 to
+disable the configured margin for from-image / from-snapshot /
+from-volume flows.
+""",
+    ),
+    cfg.FloatOpt(
+        "safe_size_margin_blank_gb",
+        default=0.25,
+        help="""
+Additional backend space (in GiB) to allocate when creating blank
+(empty) LVM-backed volumes. If unset, the driver falls back to using
+safe_size_margin_gb. Set to 0.0 to disable the margin for blank
+volumes only.
+
+The actual margin used is aligned to the VG extent size.
+""",
+    ),
+]
+
 
 RXT_VOLUME_CONF_TEMPLATE = string.Template(
     """
@@ -73,13 +112,17 @@ class RXTLVM(lvm.LVMVolumeDriver):
     """Rackspace LVM Driver.
 
     This class is used to create a new Cinder driver that gives us control of
-    the TGT helper.
+    the TGT helper and implement safer LV sizing for all volume creation
+    paths (blank volumes as well as from-image / from-snapshot /
+    from-volume use cases).
     """
 
     def __init__(self, vg_obj=None, *args, **kwargs):
 
         super(RXTLVM, self).__init__(*args, **kwargs)
+        # Base LVM options + RXT-specific options
         self.configuration.append_config_values(lvm.volume_opts)
+        self.configuration.append_config_values(rxt_volume_opts)
         self.hostname = lvm.socket.gethostname()
         self.vg = vg_obj
         self.backend_name = (
@@ -102,3 +145,318 @@ class RXTLVM(lvm.LVMVolumeDriver):
         )
 
         self._sparse_copy_volume = False
+
+    # ------------------------------------------------------------------
+    # Safe size margin helpers
+    # ------------------------------------------------------------------
+
+    def _calculate_backend_size_gb(self, volume, margin_gb):
+        """Compute LV size (GiB) including configured safety margin.
+
+        - Base is requested volume['size'] in GiB.
+        - We always align to whole VG extents.
+        - ``margin_gb`` is the configured extra backend space (in GiB) for
+          this operation. It may be 0.0 to disable extra space.
+        - End users and quota accounting still see only the requested size;
+          the extra space only exists on the backend LV.
+        """
+        base_gb = float(volume["size"])
+        base_bytes = int(base_gb * units.Gi)
+
+        # VG extent size (MiB -> bytes)
+        extent_bytes = int(self.vg.vg_extent_size * units.Mi)
+
+        # Normalise and clamp the configured margin
+        if margin_gb is None:
+            margin_gb = 0.0
+        margin_gb = max(float(margin_gb), 0.0)
+        cfg_margin_bytes = int(margin_gb * units.Gi)
+
+        margin_bytes = 0
+        if cfg_margin_bytes > 0:
+            margin_bytes = cfg_margin_bytes
+            # Ensure at least one extent worth of extra space
+            if margin_bytes < extent_bytes:
+                margin_bytes = extent_bytes
+
+        total_bytes = base_bytes + margin_bytes
+
+        # Round up to whole extents
+        extents = int(math.ceil(float(total_bytes) / float(extent_bytes)))
+        backend_bytes = extents * extent_bytes
+        backend_gb = backend_bytes / float(units.Gi)
+
+        return backend_gb, backend_bytes, margin_bytes
+
+    def _get_blank_margin_gb(self):
+        """Return safety margin (GiB) for blank volumes.
+
+        If ``safe_size_margin_blank_gb`` is unset, fall back to
+        ``safe_size_margin_gb``.
+        """
+        cfg = self.configuration
+        blank = getattr(cfg, "safe_size_margin_blank_gb", None)
+        if blank is not None:
+            return blank
+        return getattr(cfg, "safe_size_margin_gb", 0.0) or 0.0
+
+    def _get_from_source_margin_gb(self):
+        """Return safety margin (GiB) for snapshot/clone/image flows."""
+        return getattr(self.configuration, "safe_size_margin_gb", 0.0) or 0.0
+
+    def _record_safe_size_margin(self, volume, requested_size_gb,
+                                 backend_size_gb, backend_bytes,
+                                 *, margin_type=None):
+        """Log and persist the extra backend margin, if any.
+
+        This uses volume admin_metadata so operators can see when margin was
+        applied. End users still see the original requested size.
+
+        ``margin_type`` (if provided) indicates which configured margin was
+        used for this volume, e.g. "blank", "snapshot", "clone" or "image".
+        """
+        if backend_size_gb <= requested_size_gb:
+            return
+
+        used_margin_gb = backend_size_gb - requested_size_gb
+        LOG.warning(
+            "Safe size margin applied to volume %(vol)s: "
+            "%(req).3f GiB requested, %(backend).3f GiB allocated "
+            "in LVM (margin %(margin).3f GiB, raw bytes %(bytes)d).",
+            {
+                "vol": volume["id"],
+                "req": requested_size_gb,
+                "backend": backend_size_gb,
+                "margin": used_margin_gb,
+                "bytes": backend_bytes,
+            },
+        )
+
+        metadata = {"safe_size_margin_gb": f"{used_margin_gb:.3f}"}
+        if margin_type:
+            metadata["safe_size_margin_type"] = margin_type
+
+        try:
+            admin_ctxt = cinder_context.get_admin_context()
+            cinder_db.volume_admin_metadata_update(
+                admin_ctxt,
+                volume["id"],
+                metadata,
+                False,
+            )
+        except Exception:
+            LOG.exception(
+                "Failed to update admin_metadata for volume %s "
+                "with safe_size_margin_gb.",
+                volume["id"],
+            )
+
+    # ------------------------------------------------------------------
+    # Overridden methods to use safe size margin
+    # ------------------------------------------------------------------
+
+    def create_volume(self, volume):
+        """Creates a logical volume.
+
+        Plain (blank) volumes receive a configurable safety margin so that the
+        usable space on the LV is at least the requested size. The extra
+        backend space is not reflected in the Cinder-reported size.
+        """
+        mirror_count = 0
+        if self.configuration.lvm_mirrors:
+            mirror_count = self.configuration.lvm_mirrors
+
+        requested_size_gb = float(volume["size"])
+        margin_gb = self._get_blank_margin_gb()
+        backend_gb, backend_bytes, _ = self._calculate_backend_size_gb(
+            volume, margin_gb
+        )
+        lv_size_gb = int(math.ceil(backend_gb))
+
+        self._create_volume(
+            volume["name"],
+            self._sizestr(lv_size_gb),
+            self.configuration.lvm_type,
+            mirror_count,
+        )
+
+        self._record_safe_size_margin(
+            volume,
+            requested_size_gb,
+            float(lv_size_gb),
+            backend_bytes,
+            margin_type="blank",
+        )
+
+        # Base LVM driver returns None; keep that behavior
+        return None
+
+    def create_volume_from_snapshot(self, volume, snapshot):
+        """Creates a volume from a snapshot.
+
+        For non-thin volumes we allocate with a safety margin.
+        Thin volumes keep upstream behavior.
+        """
+        if self.configuration.lvm_type == "thin":
+            self.vg.create_lv_snapshot(
+                volume["name"],
+                self._escape_snapshot(snapshot["name"]),
+                self.configuration.lvm_type,
+            )
+            if volume["size"] > snapshot["volume_size"]:
+                LOG.debug("Resize the new volume to %s.", volume["size"])
+                self.extend_volume(volume, volume["size"])
+            # Some configurations of LVM do not automatically activate
+            # ThinLVM snapshot LVs.
+            self.vg.activate_lv(snapshot["name"], is_snapshot=True)
+            self.vg.activate_lv(volume["name"], is_snapshot=True, permanent=True)
+            return
+
+        requested_size_gb = float(volume["size"])
+        margin_gb = self._get_from_source_margin_gb()
+        backend_gb, backend_bytes, _ = self._calculate_backend_size_gb(
+            volume, margin_gb
+        )
+        lv_size_gb = int(math.ceil(backend_gb))
+
+        self._create_volume(
+            volume["name"],
+            self._sizestr(lv_size_gb),
+            self.configuration.lvm_type,
+            self.configuration.lvm_mirrors,
+        )
+
+        self._record_safe_size_margin(
+            volume,
+            requested_size_gb,
+            float(lv_size_gb),
+            backend_bytes,
+            margin_type="snapshot",
+        )
+
+        # Some configurations of LVM do not automatically activate
+        # ThinLVM snapshot LVs.
+        self.vg.activate_lv(snapshot["name"], is_snapshot=True)
+
+        # copy_volume expects sizes in MiB, we store integer GiB
+        volume_utils = lvm.volume_utils
+        volume_utils.copy_volume(
+            self.local_path(snapshot),
+            self.local_path(volume),
+            snapshot["volume_size"] * units.Ki,
+            self.configuration.volume_dd_blocksize,
+            execute=self._execute,
+            sparse=self._sparse_copy_volume,
+        )
+
+    def create_cloned_volume(self, volume, src_vref):
+        """Creates a clone of the specified volume.
+
+        For non-thin volumes we allocate with a safety margin.
+        Thin volumes keep upstream behavior.
+        """
+        if self.configuration.lvm_type == "thin":
+            self.vg.create_lv_snapshot(
+                volume["name"],
+                src_vref["name"],
+                self.configuration.lvm_type,
+            )
+            if volume["size"] > src_vref["size"]:
+                LOG.debug("Resize the new volume to %s.", volume["size"])
+                self.extend_volume(volume, volume["size"])
+            self.vg.activate_lv(volume["name"], is_snapshot=True, permanent=True)
+            return
+
+        mirror_count = 0
+        if self.configuration.lvm_mirrors:
+            mirror_count = self.configuration.lvm_mirrors
+        LOG.info("Creating clone of volume: %s", src_vref["id"])
+        volume_name = src_vref["name"]
+        temp_id = f"tmp-snap-{volume['id']}"
+        temp_snapshot = {
+            "volume_name": volume_name,
+            "size": src_vref["size"],
+            "volume_size": src_vref["size"],
+            "name": f"clone-snap-{volume['id']}",
+            "id": temp_id,
+        }
+
+        self.create_snapshot(temp_snapshot)
+
+        volume_utils = lvm.volume_utils
+        try:
+            requested_size_gb = float(volume["size"])
+            margin_gb = self._get_from_source_margin_gb()
+            backend_gb, backend_bytes, _ = self._calculate_backend_size_gb(
+                volume, margin_gb
+            )
+            lv_size_gb = int(math.ceil(backend_gb))
+
+            self._create_volume(
+                volume["name"],
+                self._sizestr(lv_size_gb),
+                self.configuration.lvm_type,
+                mirror_count,
+            )
+
+            self._record_safe_size_margin(
+                volume,
+                requested_size_gb,
+                float(lv_size_gb),
+                backend_bytes,
+                margin_type="clone",
+            )
+
+            self.vg.activate_lv(temp_snapshot["name"], is_snapshot=True)
+            volume_utils.copy_volume(
+                self.local_path(temp_snapshot),
+                self.local_path(volume),
+                src_vref["size"] * units.Ki,
+                self.configuration.volume_dd_blocksize,
+                execute=self._execute,
+                sparse=self._sparse_copy_volume,
+            )
+        finally:
+            self.delete_snapshot(temp_snapshot)
+
+    def copy_image_to_volume(
+        self,
+        context,
+        volume,
+        image_service,
+        image_id,
+        disable_sparse=False,
+    ):
+        """Fetch the image and write it to the volume with safety margin.
+
+        This method is only used for from-image / reimage flows, so we apply
+        the configured margin here (without changing Cinder's reported size).
+        """
+        requested_size_gb = float(volume["size"])
+        margin_gb = self._get_from_source_margin_gb()
+        backend_gb, backend_bytes, _ = self._calculate_backend_size_gb(
+            volume, margin_gb
+        )
+        lv_size_gb = int(math.ceil(backend_gb))
+
+        # If backend needs to be larger, extend LV only (DB size unchanged)
+        if lv_size_gb > volume["size"]:
+            self.extend_volume(volume, lv_size_gb)
+            self._record_safe_size_margin(
+                volume,
+                requested_size_gb,
+                float(lv_size_gb),
+                backend_bytes,
+                margin_type="image",
+            )
+
+        image_utils = lvm.image_utils
+        image_utils.fetch_to_raw(
+            context,
+            image_service,
+            image_id,
+            self.local_path(volume),
+            self.configuration.volume_dd_blocksize,
+            size=volume["size"],  # image/virtual size constraint
+            disable_sparse=disable_sparse,
+        )

--- a/cinder_rxt/test_rxt_lvm.py
+++ b/cinder_rxt/test_rxt_lvm.py
@@ -1,0 +1,299 @@
+import unittest
+from unittest import mock
+
+from cinder_rxt.rackspace import RXTLVM
+
+
+class FakeVG:
+    def __init__(self, extent_size_mib=4):
+        # Match typical LVM extent size (e.g., 4 MiB)
+        self.vg_extent_size = extent_size_mib
+
+    def activate_lv(self, name, is_snapshot=False, permanent=False):
+        # No-op for tests
+        return
+
+
+class RXTLVMTests(unittest.TestCase):
+    def _make_driver(self, **conf_overrides):
+        """Create a RXTLVM instance without running the real __init__.
+
+        We only need minimal attributes for the new sizing logic.
+        """
+        drv = RXTLVM.__new__(RXTLVM)
+        drv.vg = FakeVG()
+
+        class Conf:
+            safe_size_margin_gb = 0.25
+            safe_size_margin_blank_gb = None
+            lvm_mirrors = 0
+            lvm_type = "default"
+            volume_dd_blocksize = 1
+            # Needed by LVMVolumeDriver.local_path
+            volume_group = "fake-vg"
+
+        cfg = Conf()
+        for k, v in conf_overrides.items():
+            setattr(cfg, k, v)
+        drv.configuration = cfg
+
+        drv._sparse_copy_volume = False
+        drv._execute = lambda *a, **k: None  # stub for driver exec
+        # Reuse the same _sizestr semantics as base LVM
+        drv._sizestr = lambda sz: f"{sz}g"
+
+        return drv
+
+    def test_plain_volume_create_uses_margin_by_default(self):
+        drv = self._make_driver()
+        volume = {"id": "v1", "name": "vol-plain", "size": 10}
+
+        drv._create_volume = mock.Mock()
+        drv._record_safe_size_margin = mock.Mock()
+
+        drv.create_volume(volume)
+
+        drv._create_volume.assert_called_once()
+        name, size_str, lvm_type, mirrors = drv._create_volume.call_args[0]
+        self.assertEqual("vol-plain", name)
+        lv_size_gb = int(size_str.rstrip("g"))
+        self.assertGreater(lv_size_gb, volume["size"])
+        self.assertEqual("default", lvm_type)
+        self.assertEqual(0, mirrors)
+
+        drv._record_safe_size_margin.assert_called_once()
+        args, kwargs = drv._record_safe_size_margin.call_args
+        _, req_gb, backend_gb, backend_bytes = args
+        self.assertEqual(10.0, req_gb)
+        self.assertGreater(backend_gb, req_gb)
+        self.assertGreater(backend_bytes, 10 * 1024 * 1024 * 1024)
+        self.assertEqual("blank", kwargs.get("margin_type"))
+
+    def test_plain_volume_create_can_disable_margin_via_blank_override(self):
+        drv = self._make_driver(safe_size_margin_gb=0.5,
+                                safe_size_margin_blank_gb=0.0)
+        volume = {"id": "v1b", "name": "vol-plain-blank0", "size": 10}
+
+        drv._create_volume = mock.Mock()
+        drv._record_safe_size_margin = mock.Mock()
+
+        drv.create_volume(volume)
+
+        drv._create_volume.assert_called_once()
+        _name, size_str, _lvm_type, _mirrors = drv._create_volume.call_args[0]
+        lv_size_gb = int(size_str.rstrip("g"))
+        self.assertEqual(lv_size_gb, volume["size"])
+        drv._record_safe_size_margin.assert_not_called()
+
+    @mock.patch("cinder_rxt.rackspace.lvm.volume_utils.copy_volume")
+    def test_create_volume_from_snapshot_uses_margin(self, mock_copy_volume):
+        drv = self._make_driver(safe_size_margin_gb=0.25,
+                                safe_size_margin_blank_gb=0.0)
+        volume = {"id": "v2", "name": "vol-from-snap", "size": 10}
+        snapshot = {"name": "snap-001", "volume_size": 10}
+
+        drv._create_volume = mock.Mock()
+        drv._record_safe_size_margin = mock.Mock()
+
+        drv.create_volume_from_snapshot(volume, snapshot)
+
+        drv._create_volume.assert_called_once()
+        _name, size_str, _lvm_type, _mirrors = drv._create_volume.call_args[0]
+        # LV size should be strictly larger than requested 10 GiB
+        self.assertEqual("vol-from-snap", _name)
+        lv_size_gb = int(size_str.rstrip("g"))
+        self.assertGreater(lv_size_gb, 10)
+
+        drv._record_safe_size_margin.assert_called_once()
+        args, kwargs = drv._record_safe_size_margin.call_args
+        _, req_gb, backend_gb, backend_bytes = args
+        self.assertEqual(10.0, req_gb)
+        self.assertGreater(backend_gb, req_gb)
+        self.assertGreater(backend_bytes, 10 * 1024 * 1024 * 1024)
+        self.assertEqual("snapshot", kwargs.get("margin_type"))
+
+        # copy_volume should be called with snapshot size in MiB
+        mock_copy_volume.assert_called_once()
+        src, dst, size_mib, blocksize = mock_copy_volume.call_args[0][:4]
+        self.assertEqual(snapshot["volume_size"] * 1024, size_mib)
+
+    @mock.patch("cinder_rxt.rackspace.lvm.volume_utils.copy_volume")
+    def test_create_cloned_volume_uses_margin(self, mock_copy_volume):
+        drv = self._make_driver(safe_size_margin_gb=0.25,
+                                safe_size_margin_blank_gb=0.0)
+        volume = {"id": "v3", "name": "vol-clone", "size": 10}
+        src_vref = {"id": "src1", "name": "src-vol", "size": 10}
+
+        drv._create_volume = mock.Mock()
+        drv._record_safe_size_margin = mock.Mock()
+        drv.create_snapshot = mock.Mock()
+        drv.delete_snapshot = mock.Mock()
+
+        drv.create_cloned_volume(volume, src_vref)
+
+        drv._create_volume.assert_called_once()
+        _name, size_str, _lvm_type, _mirrors = drv._create_volume.call_args[0]
+        self.assertEqual("vol-clone", _name)
+        lv_size_gb = int(size_str.rstrip("g"))
+        self.assertGreater(lv_size_gb, 10)
+
+        drv._record_safe_size_margin.assert_called_once()
+        _args, kwargs = drv._record_safe_size_margin.call_args
+        self.assertEqual("clone", kwargs.get("margin_type"))
+        mock_copy_volume.assert_called_once()
+
+    @mock.patch("cinder_rxt.rackspace.cinder_db.volume_admin_metadata_update")
+    @mock.patch("cinder_rxt.rackspace.cinder_context.get_admin_context")
+    def test_record_safe_size_margin_writes_expected_admin_metadata_blank(
+        self, mock_get_admin_context, mock_volume_admin_metadata_update
+    ):
+        drv = self._make_driver(safe_size_margin_gb=0.25,
+                                safe_size_margin_blank_gb=0.25)
+        volume = {"id": "v-meta-blank", "name": "vol-meta-blank", "size": 10}
+
+        drv._create_volume = mock.Mock()
+
+        drv.create_volume(volume)
+
+        mock_get_admin_context.assert_called_once()
+        mock_volume_admin_metadata_update.assert_called_once()
+        _ctxt, vol_id, metadata, update = \
+            mock_volume_admin_metadata_update.call_args[0]
+
+        self.assertEqual("v-meta-blank", vol_id)
+        # Margin must be positive and recorded
+        margin_str = metadata.get("safe_size_margin_gb")
+        self.assertIsNotNone(margin_str)
+        self.assertGreater(float(margin_str), 0.0)
+        self.assertEqual("blank", metadata.get("safe_size_margin_type"))
+        self.assertFalse(update)
+
+    @mock.patch("cinder_rxt.rackspace.cinder_db.volume_admin_metadata_update")
+    @mock.patch("cinder_rxt.rackspace.cinder_context.get_admin_context")
+    def test_record_safe_size_margin_writes_expected_admin_metadata_snapshot(
+        self, mock_get_admin_context, mock_volume_admin_metadata_update
+    ):
+        drv = self._make_driver(safe_size_margin_gb=0.25,
+                                safe_size_margin_blank_gb=0.0)
+        volume = {"id": "v-meta-snap", "name": "vol-meta-snap", "size": 10}
+        snapshot = {"name": "snap-meta", "volume_size": 10}
+
+        drv._create_volume = mock.Mock()
+
+        drv.create_volume_from_snapshot(volume, snapshot)
+
+        mock_get_admin_context.assert_called_once()
+        mock_volume_admin_metadata_update.assert_called_once()
+        _ctxt, vol_id, metadata, update = \
+            mock_volume_admin_metadata_update.call_args[0]
+
+        self.assertEqual("v-meta-snap", vol_id)
+        margin_str = metadata.get("safe_size_margin_gb")
+        self.assertIsNotNone(margin_str)
+        self.assertGreater(float(margin_str), 0.0)
+        self.assertEqual("snapshot", metadata.get("safe_size_margin_type"))
+        self.assertFalse(update)
+
+    @mock.patch("cinder_rxt.rackspace.lvm.volume_utils.copy_volume")
+    @mock.patch("cinder_rxt.rackspace.cinder_db.volume_admin_metadata_update")
+    @mock.patch("cinder_rxt.rackspace.cinder_context.get_admin_context")
+    def test_record_safe_size_margin_writes_expected_admin_metadata_clone(
+        self,
+        mock_get_admin_context,
+        mock_volume_admin_metadata_update,
+        mock_copy_volume,
+    ):
+        drv = self._make_driver(safe_size_margin_gb=0.25,
+                                safe_size_margin_blank_gb=0.0)
+        volume = {"id": "v-meta-clone", "name": "vol-meta-clone", "size": 10}
+        src_vref = {"id": "src-meta", "name": "src-vol-meta", "size": 10}
+
+        drv._create_volume = mock.Mock()
+        drv.create_snapshot = mock.Mock()
+        drv.delete_snapshot = mock.Mock()
+
+        drv.create_cloned_volume(volume, src_vref)
+
+        mock_get_admin_context.assert_called_once()
+        mock_volume_admin_metadata_update.assert_called_once()
+        _ctxt, vol_id, metadata, update = \
+            mock_volume_admin_metadata_update.call_args[0]
+
+        self.assertEqual("v-meta-clone", vol_id)
+        margin_str = metadata.get("safe_size_margin_gb")
+        self.assertIsNotNone(margin_str)
+        self.assertGreater(float(margin_str), 0.0)
+        self.assertEqual("clone", metadata.get("safe_size_margin_type"))
+        self.assertFalse(update)
+
+    @mock.patch("cinder_rxt.rackspace.lvm.image_utils.fetch_to_raw")
+    @mock.patch("cinder_rxt.rackspace.cinder_db.volume_admin_metadata_update")
+    @mock.patch("cinder_rxt.rackspace.cinder_context.get_admin_context")
+    def test_record_safe_size_margin_writes_expected_admin_metadata_image(
+        self,
+        mock_get_admin_context,
+        mock_volume_admin_metadata_update,
+        mock_fetch,
+    ):
+        drv = self._make_driver(safe_size_margin_gb=0.25,
+                                safe_size_margin_blank_gb=0.0)
+        volume = {"id": "v-meta-img", "name": "vol-meta-img", "size": 10}
+
+        drv.extend_volume = mock.Mock()
+
+        drv.copy_image_to_volume(
+            context=mock.sentinel.ctx,
+            volume=volume,
+            image_service=mock.sentinel.img_svc,
+            image_id="img-meta",
+            disable_sparse=False,
+        )
+
+        mock_get_admin_context.assert_called_once()
+        mock_volume_admin_metadata_update.assert_called_once()
+        _ctxt, vol_id, metadata, update = \
+            mock_volume_admin_metadata_update.call_args[0]
+
+        self.assertEqual("v-meta-img", vol_id)
+        margin_str = metadata.get("safe_size_margin_gb")
+        self.assertIsNotNone(margin_str)
+        self.assertGreater(float(margin_str), 0.0)
+        self.assertEqual("image", metadata.get("safe_size_margin_type"))
+        self.assertFalse(update)
+
+    @mock.patch("cinder_rxt.rackspace.lvm.image_utils.fetch_to_raw")
+    def test_copy_image_to_volume_extends_and_records_margin(self, mock_fetch):
+        drv = self._make_driver(safe_size_margin_gb=0.25,
+                                safe_size_margin_blank_gb=0.0)
+        volume = {"id": "v4", "name": "vol-img", "size": 10}
+
+        drv.extend_volume = mock.Mock()
+        drv._record_safe_size_margin = mock.Mock()
+
+        drv.copy_image_to_volume(
+            context=mock.sentinel.ctx,
+            volume=volume,
+            image_service=mock.sentinel.img_svc,
+            image_id="img-123",
+            disable_sparse=False,
+        )
+
+        # Since margin is applied, extend_volume should be called
+        drv.extend_volume.assert_called_once()
+        _vol_arg, new_size = drv.extend_volume.call_args[0]
+        self.assertIs(_vol_arg, volume)
+        self.assertGreater(new_size, volume["size"])
+
+        drv._record_safe_size_margin.assert_called_once()
+        _args, kwargs = drv._record_safe_size_margin.call_args
+        self.assertEqual("image", kwargs.get("margin_type"))
+
+        mock_fetch.assert_called_once()
+        args, kwargs = mock_fetch.call_args
+        _ctx, _svc, _img_id, dest_path, blocksize = args[:5]
+        # size argument passed to fetch_to_raw must be the requested size
+        self.assertEqual(volume["size"], kwargs.get("size"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…location

Addresses: [OSPC-1573](https://rackspace.atlassian.net/browse/OSPC-1573)

Implements automatic oversizing of logical volumes with configurable margins to prevent out-of-space errors during volume operations.

Changes:
- Add two new config options:
  * safe_size_margin_gb: margin for volumes created from snapshots, clones, or images (default: 0.25 GB)
  * safe_size_margin_blank_gb: margin for blank volumes (default: 0.25 GB)

- Override volume creation methods to apply safety margins:
  * create_volume: applies blank volume margin
  * create_volume_from_snapshot: applies from-source margin
  * create_cloned_volume: applies from-source margin
  * copy_image_to_volume: applies from-source margin

- New helper functions:
  * _calculate_backend_size_gb: computes final LV size with margin and VG extent alignment
  * _get_blank_margin_gb: retrieves blank volume margin setting
  * _get_from_source_margin_gb: retrieves from-source margin setting
  * _record_safe_size_margin: stores margin metadata on volume

- Record margin info in volume admin metadata:
  * safe_size_margin_gb: actual margin applied in GB
  * safe_size_margin_type: either "blank" or "from_source"

- Add comprehensive unit tests in test_rxt_lvm.py covering all creation paths and margin configurations