### PR TITLE
Fix: OSPC-1573 Resize volume after qemu-img convert and Luks headers

### DIFF
--- a/cinder_rxt/rackspace.py
+++ b/cinder_rxt/rackspace.py
@@ -12,15 +12,24 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import math
 import string
 import textwrap
 
+from oslo_concurrency import processutils as putils
 from oslo_log import log as logging
+from oslo_utils import units
 
 from cinder.volume.drivers import lvm
 from cinder.volume.targets import tgt
 
 LOG = logging.getLogger(__name__)
+
+# LUKS1 header is 2 MiB; LUKS2 header is 16 MiB.  We use 16 MiB to
+# cover both formats.  This is the minimum extra space the LV needs so
+# that the decrypted dm-crypt device is at least as large as the
+# requested volume size.
+_LUKS_HEADER_BYTES = 16 * units.Mi
 
 RXT_VOLUME_CONF_TEMPLATE = string.Template(
     """
@@ -73,7 +82,21 @@ class RXTLVM(lvm.LVMVolumeDriver):
     """Rackspace LVM Driver.
 
     This class is used to create a new Cinder driver that gives us control of
-    the TGT helper.
+    the TGT helper and to work around a sizing issue when writing images to
+    encrypted LVM volumes.
+
+    When cinder writes an image to an encrypted volume the LUKS header
+    consumes space on the LV, leaving the decrypted dm-crypt device
+    smaller than the requested volume size.  For example a 40 GiB LV
+    yields only ~39.998 GiB of usable space after LUKS1 formatting
+    (or ~39.984 GiB with LUKS2).  ``qemu-img convert`` then fails with
+    "Cannot grow device files" because the image's virtual size exceeds
+    the decrypted device.
+
+    The fix is minimal: before writing the image we extend the LV by
+    enough VG physical extents to cover the LUKS header, then shrink it
+    back after the write completes so that backup tools that capture the
+    raw block device see the correct size.
     """
 
     def __init__(self, vg_obj=None, *args, **kwargs):
@@ -102,3 +125,81 @@ class RXTLVM(lvm.LVMVolumeDriver):
         )
 
         self._sparse_copy_volume = False
+
+    # ------------------------------------------------------------------
+    # LUKS header compensation for encrypted image-to-volume copies
+    # ------------------------------------------------------------------
+
+    def _get_extent_size_bytes(self):
+        """Return the VG physical extent size in bytes."""
+        # vg_extent_size is in MiB (float) on the brick LVM object
+        return int(float(self.vg.vg_extent_size) * units.Mi)
+
+    def _lvresize(self, volume, size_str):
+        """Resize an LV using lvresize (supports both grow and shrink).
+
+        This is needed because os-brick's LVM class only exposes
+        ``extend_volume`` (lvextend) which cannot shrink.
+        """
+        lv_path = "%s/%s" % (self.vg.vg_name, volume["name"])
+        cmd = ["env", "LC_ALL=C", "lvresize", "-f",
+               "-L", size_str, lv_path]
+        putils.execute(*cmd, run_as_root=True,
+                       root_helper=self.vg._root_helper)
+
+    def copy_image_to_encrypted_volume(
+        self, context, volume, image_service, image_id,
+        disable_sparse=False,
+    ):
+        """Fetch image and write to an encrypted volume.
+
+        Before writing, temporarily extend the LV by enough extents to
+        cover the LUKS header so it does not eat into the usable space.
+        After the write succeeds, shrink the LV back to the original
+        size to prevent backup tools from capturing the oversized block
+        device.
+        """
+        extent_bytes = self._get_extent_size_bytes()
+        # LUKS2 header is 16 MiB and the default PE is 4 MiB, so we
+        # may need up to 4 extents.  Calculate the minimum number of
+        # extents to cover the LUKS header.
+        extra_extents = int(math.ceil(_LUKS_HEADER_BYTES / extent_bytes))
+        extra_bytes = extra_extents * extent_bytes
+
+        original_bytes = int(volume["size"]) * units.Gi
+        extended_bytes = original_bytes + extra_bytes
+        original_str = self._sizestr(volume["size"])
+
+        LOG.info(
+            "Extending LV for encrypted volume %(vol)s by %(extra)d bytes "
+            "(%(extents)d extents) to accommodate LUKS header before "
+            "image copy.",
+            {"vol": volume["id"], "extra": extra_bytes,
+             "extents": extra_extents},
+        )
+
+        self.extend_volume(volume, extended_bytes / float(units.Gi))
+
+        try:
+            # Delegate to the base driver which handles attaching,
+            # LUKS encryptor setup, fetch_to_raw, and detaching.
+            self._copy_image_data_to_volume(
+                context, volume, image_service, image_id,
+                encrypted=True, disable_sparse=disable_sparse,
+            )
+        finally:
+            # Always attempt to shrink back, even on failure, so we
+            # don't leave an oversized LV.
+            try:
+                self._lvresize(volume, original_str)
+                LOG.info(
+                    "LV for volume %(vol)s shrunk back to %(size)s after "
+                    "encrypted image copy.",
+                    {"vol": volume["id"], "size": original_str},
+                )
+            except putils.ProcessExecutionError:
+                LOG.warning(
+                    "Failed to shrink LV for volume %(vol)s back to "
+                    "%(size)s. The LV will remain at the extended size.",
+                    {"vol": volume["id"], "size": original_str},
+                )

--- a/cinder_rxt/test_rxt_lvm.py
+++ b/cinder_rxt/test_rxt_lvm.py
@@ -1,0 +1,172 @@
+import unittest
+from unittest import mock
+
+from oslo_concurrency import processutils as putils
+from oslo_utils import units
+
+from cinder_rxt.rackspace import RXTLVM, _LUKS_HEADER_BYTES
+
+
+class FakeVG:
+    def __init__(self, extent_size_mib=4):
+        self.vg_extent_size = extent_size_mib
+        self.vg_name = "fake-vg"
+        self._root_helper = "sudo cinder-rootwrap /etc/cinder/rootwrap.conf"
+
+
+class TestCopyImageToEncryptedVolume(unittest.TestCase):
+    """Tests for the LUKS header compensation in copy_image_to_encrypted_volume."""
+
+    def _make_driver(self):
+        """Create an RXTLVM instance without running the real __init__."""
+        drv = RXTLVM.__new__(RXTLVM)
+        drv.vg = FakeVG()
+        drv._sparse_copy_volume = False
+        drv._execute = lambda *a, **k: None
+        drv._sizestr = lambda sz: "%sg" % sz
+
+        class Conf:
+            volume_dd_blocksize = 1
+            volume_group = "fake-vg"
+            use_multipath_for_image_xfer = False
+            enforce_multipath_for_image_xfer = False
+
+        drv.configuration = Conf()
+        return drv
+
+    def test_get_extent_size_bytes(self):
+        drv = self._make_driver()
+        # Default FakeVG has 4 MiB extents
+        self.assertEqual(4 * units.Mi, drv._get_extent_size_bytes())
+
+    def test_get_extent_size_bytes_custom(self):
+        drv = self._make_driver()
+        drv.vg = FakeVG(extent_size_mib=8)
+        self.assertEqual(8 * units.Mi, drv._get_extent_size_bytes())
+
+    @mock.patch("cinder_rxt.rackspace.putils.execute")
+    def test_lvresize_calls_correct_command(self, mock_execute):
+        drv = self._make_driver()
+        volume = {"id": "v1", "name": "vol-1", "size": 10}
+
+        drv._lvresize(volume, "10g")
+
+        mock_execute.assert_called_once()
+        args, kwargs = mock_execute.call_args
+        self.assertEqual(
+            ("env", "LC_ALL=C", "lvresize", "-f", "-L", "10g",
+             "fake-vg/vol-1"),
+            args,
+        )
+        self.assertTrue(kwargs["run_as_root"])
+
+    @mock.patch("cinder_rxt.rackspace.putils.execute")
+    def test_extends_lv_before_image_copy_and_shrinks_after(
+        self, mock_lvresize_execute
+    ):
+        drv = self._make_driver()
+        volume = {"id": "v1", "name": "vol-enc", "size": 40}
+
+        drv.extend_volume = mock.Mock()
+        drv._copy_image_data_to_volume = mock.Mock()
+
+        drv.copy_image_to_encrypted_volume(
+            context=mock.sentinel.ctx,
+            volume=volume,
+            image_service=mock.sentinel.img_svc,
+            image_id="img-1",
+        )
+
+        # LV should be extended before the copy
+        drv.extend_volume.assert_called_once()
+        _, extended_gb = drv.extend_volume.call_args[0]
+        # With 4 MiB extents and 16 MiB LUKS header: 4 extra extents
+        expected_extra = 4 * 4 * units.Mi  # 16 MiB
+        expected_gb = (40 * units.Gi + expected_extra) / float(units.Gi)
+        self.assertAlmostEqual(extended_gb, expected_gb, places=6)
+
+        # Image copy should have been called with encrypted=True
+        drv._copy_image_data_to_volume.assert_called_once_with(
+            mock.sentinel.ctx, volume, mock.sentinel.img_svc, "img-1",
+            encrypted=True, disable_sparse=False,
+        )
+
+        # LV should be shrunk back after the copy
+        mock_lvresize_execute.assert_called_once()
+        args = mock_lvresize_execute.call_args[0]
+        self.assertEqual("lvresize", args[2])
+        # Target size should be the original volume size
+        self.assertEqual("40g", args[5])
+
+    @mock.patch("cinder_rxt.rackspace.putils.execute")
+    def test_shrinks_lv_even_when_image_copy_fails(
+        self, mock_lvresize_execute
+    ):
+        drv = self._make_driver()
+        volume = {"id": "v2", "name": "vol-fail", "size": 10}
+
+        drv.extend_volume = mock.Mock()
+        drv._copy_image_data_to_volume = mock.Mock(
+            side_effect=Exception("image copy failed")
+        )
+
+        with self.assertRaises(Exception, msg="image copy failed"):
+            drv.copy_image_to_encrypted_volume(
+                context=mock.sentinel.ctx,
+                volume=volume,
+                image_service=mock.sentinel.img_svc,
+                image_id="img-2",
+            )
+
+        # LV should still be shrunk back despite the failure
+        mock_lvresize_execute.assert_called_once()
+
+    @mock.patch("cinder_rxt.rackspace.putils.execute")
+    def test_lvresize_failure_is_non_fatal(self, mock_lvresize_execute):
+        """If lvresize fails after image copy, log warning but don't raise."""
+        mock_lvresize_execute.side_effect = putils.ProcessExecutionError(
+            exit_code=1, stderr="lvresize failed"
+        )
+        drv = self._make_driver()
+        volume = {"id": "v3", "name": "vol-shrink-fail", "size": 10}
+
+        drv.extend_volume = mock.Mock()
+        drv._copy_image_data_to_volume = mock.Mock()
+
+        # Should not raise
+        drv.copy_image_to_encrypted_volume(
+            context=mock.sentinel.ctx,
+            volume=volume,
+            image_service=mock.sentinel.img_svc,
+            image_id="img-3",
+        )
+
+        # Image copy should have succeeded
+        drv._copy_image_data_to_volume.assert_called_once()
+
+    @mock.patch("cinder_rxt.rackspace.putils.execute")
+    def test_extra_extents_scale_with_pe_size(self, mock_lvresize_execute):
+        """With larger PE sizes, fewer extents are needed."""
+        drv = self._make_driver()
+        # 16 MiB extents: only 1 extent needed for 16 MiB LUKS header
+        drv.vg = FakeVG(extent_size_mib=16)
+        volume = {"id": "v4", "name": "vol-big-pe", "size": 10}
+
+        drv.extend_volume = mock.Mock()
+        drv._copy_image_data_to_volume = mock.Mock()
+
+        drv.copy_image_to_encrypted_volume(
+            context=mock.sentinel.ctx,
+            volume=volume,
+            image_service=mock.sentinel.img_svc,
+            image_id="img-4",
+        )
+
+        _, extended_gb = drv.extend_volume.call_args[0]
+        # 1 extent of 16 MiB
+        expected_gb = (10 * units.Gi + 16 * units.Mi) / float(units.Gi)
+        self.assertAlmostEqual(extended_gb, expected_gb, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Currently, the default volume.filters with rootwrap.d supplied by cinder/pip or via the Cinder Helm container image do not contain lvresize. This commit needs to be merged prior to merging PR Genestack/#1464. (They must both be pulled to the overseer before deployment)

Functions added that will utilize lvresize in rootwrap.d:

_get_extent_size_bytes() — reads the VG physical extent 
size _lvresize() — wraps lvresize -f for grow/shrink (needs the rootwrap filter)
copy_image_to_encrypted_volume() — the only override needed: Calculates extra extents to cover LUKS header (16 MiB / PE size) 
- Extends LV
- Delegates to base _copy_image_data_to_volume(encrypted=True) which handles LUKS setup + fetch_to_raw 
- Shrinks LV back in a finally block (non-fatal if it fails)