### PR TITLE
Fix!: Final correction to lvresize operation

### DIFF
--- a/cinder_rxt/rackspace.py
+++ b/cinder_rxt/rackspace.py
@@ -150,30 +150,14 @@ class RXTLVM(lvm.LVMVolumeDriver):
         This is needed because os-brick's LVM class only exposes
         ``extend_volume`` (lvextend) which cannot shrink.
 
-        The LV is deactivated before shrinking because dm-crypt or
-        iSCSI holders may not have been fully released yet.  After
-        the resize the LV is reactivated.
-
-        Commands use bare invocations (no env prefix) matched by
-        rootwrap ``CommandFilter`` entries.
+        If the resize fails (e.g. because dm-crypt holders have not
+        been fully released), the caller is expected to catch
+        ``ProcessExecutionError`` and leave the LV at its current size.
         """
         lv_path = "%s/%s" % (self.vg.vg_name, volume["name"])
-        _exec = putils.execute
-        rh = self.vg._root_helper
-
-        _exec("lvchange", "-an", lv_path,
-              run_as_root=True, root_helper=rh)
-        try:
-            _exec("lvresize", "-f", "-L", size_str, lv_path,
-                  run_as_root=True, root_helper=rh)
-        finally:
-            try:
-                _exec("lvchange", "-ay", "-K", lv_path,
-                      run_as_root=True, root_helper=rh)
-            except putils.ProcessExecutionError:
-                LOG.exception(
-                    "Failed to reactivate LV %s after resize attempt. "
-                    "Manual intervention may be required.", lv_path)
+        putils.execute("lvresize", "-f", "-L", size_str, lv_path,
+                       run_as_root=True,
+                       root_helper=self.vg._root_helper)
 
     def copy_image_to_encrypted_volume(
         self, context, volume, image_service, image_id,

--- a/cinder_rxt/test_rxt_lvm.py
+++ b/cinder_rxt/test_rxt_lvm.py
@@ -53,26 +53,15 @@ class TestCopyImageToEncryptedVolume(unittest.TestCase):
         self.assertEqual(8 * units.Mi, drv._get_extent_size_bytes())
 
     @mock.patch("cinder_rxt.rackspace.putils.execute")
-    def test_lvresize_calls_correct_commands(self, mock_execute):
+    def test_lvresize_calls_correct_command(self, mock_execute):
         drv = self._make_driver()
         volume = {"id": "v1", "name": "vol-1", "size": 10}
 
         drv._lvresize(volume, "10g")
 
-        self.assertEqual(mock_execute.call_count, 3)
-        calls = mock_execute.call_args_list
-
-        # 1. deactivate
-        self.assertEqual(
-            calls[0][0], ("lvchange", "-an", "fake-vg/vol-1"))
-        # 2. resize
-        self.assertEqual(
-            calls[1][0],
-            ("lvresize", "-f", "-L", "10g", "fake-vg/vol-1"))
-        # 3. reactivate
-        self.assertEqual(
-            calls[2][0],
-            ("lvchange", "-ay", "-K", "fake-vg/vol-1"))
+        mock_execute.assert_called_once_with(
+            "lvresize", "-f", "-L", "10g", "fake-vg/vol-1",
+            run_as_root=True, root_helper=drv.vg._root_helper)
 
     @mock.patch("cinder_rxt.rackspace.putils.execute")
     def test_extends_lv_before_image_copy_and_shrinks_after(
@@ -105,12 +94,12 @@ class TestCopyImageToEncryptedVolume(unittest.TestCase):
             encrypted=True, disable_sparse=False,
         )
 
-        # LV should be shrunk back after the copy (deactivate, resize, activate)
-        self.assertEqual(mock_lvresize_execute.call_count, 3)
-        resize_args = mock_lvresize_execute.call_args_list[1][0]
-        self.assertEqual("lvresize", resize_args[0])
+        # LV should be shrunk back after the copy
+        mock_lvresize_execute.assert_called_once()
+        args = mock_lvresize_execute.call_args[0]
+        self.assertEqual("lvresize", args[0])
         # Target size should be the original volume size
-        self.assertEqual("40g", resize_args[3])
+        self.assertEqual("40g", args[3])
 
     @mock.patch("cinder_rxt.rackspace.putils.execute")
     def test_shrinks_lv_even_when_image_copy_fails(
@@ -133,18 +122,13 @@ class TestCopyImageToEncryptedVolume(unittest.TestCase):
             )
 
         # LV should still be shrunk back despite the failure
-        # (deactivate, resize, activate = 3 calls)
-        self.assertEqual(mock_lvresize_execute.call_count, 3)
+        mock_lvresize_execute.assert_called_once()
 
     @mock.patch("cinder_rxt.rackspace.putils.execute")
     def test_lvresize_failure_is_non_fatal(self, mock_execute):
         """If lvresize fails after image copy, log warning but don't raise."""
-        def _selective_fail(*args, **kwargs):
-            if "lvresize" in args:
-                raise putils.ProcessExecutionError(
-                    exit_code=1, stderr="lvresize failed")
-
-        mock_execute.side_effect = _selective_fail
+        mock_execute.side_effect = putils.ProcessExecutionError(
+            exit_code=1, stderr="lvresize failed")
         drv = self._make_driver()
         volume = {"id": "v3", "name": "vol-shrink-fail", "size": 10}
 


### PR DESCRIPTION
vgchange was too risky to run in the case where
deactivate was completed but activate couldn't be
achieved. There is no danger in 16 MiB additional LV size. If the resize succeeds then that's wonderful. If the async operation from LUKS dm-crypt teardown doesn't complete and the resize doesn't go through we fail gracefully and allow the extra 16 MiB. This does not affect subsequent clones or snapshots and is transparent to the customer. No additional charge for the 16 MiB.